### PR TITLE
fix : falta comilla

### DIFF
--- a/decide/local_settings.example.py
+++ b/decide/local_settings.example.py
@@ -29,7 +29,7 @@ BASEURL = 'http://10.5.0.1:8000'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql,
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'postgres',
         'USER': 'postgres',
         'HOST': 'db',


### PR DESCRIPTION
Falta de comilla para cerrar un parámetro en el fichero local_settings_example.py